### PR TITLE
Update HomepageFeatures to use Docusaurus Link component

### DIFF
--- a/docs/products/nachet/introduction.md
+++ b/docs/products/nachet/introduction.md
@@ -43,7 +43,7 @@ Currently we are training our models to identify these 15 species:
 
 For more information about the CFIA's Seed Program, visit the [Seeds
 identification
-page](https://inspection.canada.ca/plant-health/seeds/seed-testing-and-grading/seeds-identification/eng/1333136604307/1333136685768).
+page](https://inspection.canada.ca/en/plant-health/seeds/seed-testing-and-grading/seeds-identification).
 
 ## Web App
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/products/finesse/introduction.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/products/finesse/introduction.md
@@ -37,9 +37,9 @@ internes. Les outils actuellement à la disposition des employés de l'ACIA pour
 rechercher des documents internes sont principalement basés sur des mots-clés,
 ce qui est dépassé. Trouver les bonnes informations est difficile et souvent
 pénible pour les employés. Un exemple de ceci est l'outil Guidance Finder,
-accessible à [Guidance Finder](https://inspection.canada.ca/apps/eng/guidance).
-En réponse, nous développons Finesse, un moteur de recherche sémantique conçu
-pour rechercher efficacement des ensembles de documents internes et améliorer
+accessible sur [cette page](https://inspection.canada.ca/fr/orientation). En
+réponse, nous développons Finesse, un moteur de recherche sémantique conçu pour
+rechercher efficacement des ensembles de documents internes et améliorer
 l'expérience de recherche pour nos employés.
 
 ## À qui est-il destiné ?

--- a/i18n/fr/docusaurus-plugin-content-docs/current/products/nachet/introduction.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/products/nachet/introduction.md
@@ -48,7 +48,7 @@ Nous formons actuellement nos modèles pour identifier ces 15 espèces :
 
 Pour plus d'informations sur le Programme des semences de l'ACIA, consultez la
 [page d'identification des
-semences](https://inspection.canada.ca/plant-health/seeds/seed-testing-and-grading/seeds-identification/eng/1333136604307/1333136685768).
+semences](https://inspection.canada.ca/fr/protection-vegetaux/semences/analyse-semences-designation-categorie/identification-semences).
 
 ## Application Web
 

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -2,6 +2,8 @@ import React from "react";
 import clsx from "clsx";
 import styles from "./styles.module.css";
 import Translate from "@docusaurus/Translate";
+import Link from '@docusaurus/Link';
+
 
 const FeatureList = [
   {
@@ -29,11 +31,11 @@ function Feature({ Svg, title, description, link }) {
   return (
     <div className={clsx("col")}>
       <div className="text--center padding-horiz--md">
-        <a href={link}>
+        <Link to={link}>
           <Svg className={styles.featureSvg} role="img" />
           <h3>{title}</h3>
           <p>{description}</p>
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request updates the HomepageFeatures component to use the Docusaurus Link component instead of the anchor tag for links. This change improves accessibility and ensures consistent navigation behavior across the site whether the site is in french or in english.