### PR TITLE
add serve as static web app serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 AS build
+FROM node:18
 
 WORKDIR /app
 
@@ -10,4 +10,8 @@ COPY . .
 
 RUN yarn build
 
-CMD ["npm", "run", "serve"]
+RUN yarn global add serve
+
+EXPOSE 3000
+
+CMD ["serve", "-s", "build", "-l", "3000"]

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Then you can run:
 npm run serve
 ```
 
-## Deployment
+## Docker
 
-Using SSH:
+To build the Docker image, run:
 
 ```bash
-USE_SSH=true yarn deploy
+docker build -t ailab .
 ```
 
-Not using SSH:
+To run the Docker image, run:
 
 ```bash
-GIT_USER=<Your GitHub username> yarn deploy
+docker run -p 3000:3000 ailab
 ```


### PR DESCRIPTION
This was tested to work with our new security configuration on the cluster. [Serve](https://classic.yarnpkg.com/en/package/serve) is a yarn package destined for static file serving used and created by vercel.